### PR TITLE
BUGIFX: duplicate entry for "/var/log/redis/redis-server.log"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,12 +117,16 @@ class redis (
     notify  => Service['redis'],
   }
 
-  file { '/etc/logrotate.d/redis':
-    path    => '/etc/logrotate.d/redis',
+  file { '/etc/logrotate.d/redis-server':
+    path    => '/etc/logrotate.d/redis-server',
     content => template('redis/redis.logrotate.erb'),
     owner   => root,
     group   => root,
     mode    => '0644',
+  }
+  file { '/etc/logrotate.d/redis':
+    path    => '/etc/logrotate.d/redis',
+    ensure  => absent,
   }
 
   exec { $conf_dir:


### PR DESCRIPTION
This change fixes the error "Duplicate entry for /var/log/redis/redis-server.log" caused because both the module and debian package add different logrotate files for "redis-server". (fix #4).
