### PR TITLE
Install package before poking config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,7 @@ class redis (
     owner   => root,
     group   => root,
     mode    => '0644',
+    require => Package['redis'],
     notify  => Service['redis'],
   }
 


### PR DESCRIPTION
For RedHat-y OSen, `$conf_redis` is `/etc/redis.conf`, so there's no
dependency, but for Debian/Ubuntu, it's `/etc/redis/conf` - that dir is
created by the Debian/Ubuntu redis packages, so while a `file` might
make sense, cribbing from
http://www.devco.net/archives/2012/12/13/simple-puppet-module-structure-redux.php
and having config depend on package seems cleaner
