### PR TITLE
Add glueoutputbuf config option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class redis (
   $conf_zset_max_ziplist_value      = '64',
   $conf_activerehashing             = 'yes',
   $conf_include                     = UNSET,
+  $conf_glueoutputbuf               = 'yes',
 ) {
 
   include redis::params

--- a/templates/redis.debian.conf.erb
+++ b/templates/redis.debian.conf.erb
@@ -197,7 +197,9 @@ appendfsync <%= @conf_appendfsync %>
 # Glue small output buffers together in order to send small replies in a
 # single TCP packet. Uses a bit more CPU but most of the times it is a win
 # in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
+<% if @conf_glueoutputbuf != 'UNSET' %>
+glueoutputbuf <%= @conf_glueoutputbuf %>
+<% end %>
 
 # Use object sharing. Can save a lot of memory if you have many common
 # string in your dataset, but performs lookups against the shared objects


### PR DESCRIPTION
This change allows a workaround for issue #8 while leaving the defaults for backwards compatibility.
