### PR TITLE
removes glueoutputbuf setting

### DIFF
--- a/templates/redis.debian.conf.erb
+++ b/templates/redis.debian.conf.erb
@@ -194,11 +194,6 @@ appendfsync <%= @conf_appendfsync %>
 
 ############################### ADVANCED CONFIG ###############################
 
-# Glue small output buffers together in order to send small replies in a
-# single TCP packet. Uses a bit more CPU but most of the times it is a win
-# in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
-
 # Use object sharing. Can save a lot of memory if you have many common
 # string in your dataset, but performs lookups against the shared objects
 # pool so it uses more CPU and can be a bit slower. Usually it's a good


### PR DESCRIPTION
`glueoutputbuf` does not seem to be supported in redis-server `2.6.7` anymore.
I'm not sure about the exact version of redis that stopped supporting it.
