### PR TITLE
ensure correct permissions on redis conf_dir - so it can actually write ...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,6 +147,7 @@ class redis (
     ensure  => directory,
     owner   => redis,
     group   => redis,
+    mode    => 0755,
     before  => Service['redis'],
     require => Exec[$conf_dir],
   }


### PR DESCRIPTION
...DB where the conf tells it to
