### PR TITLE
Changing default of glueoutputbuf to UNSET since it has been removed fro...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class redis (
   $conf_zset_max_ziplist_value      = '64',
   $conf_activerehashing             = 'yes',
   $conf_include                     = 'UNSET',
-  $conf_glueoutputbuf               = 'yes',
+  $conf_glueoutputbuf               = 'UNSET',
 ) {
 
   include redis::params


### PR DESCRIPTION
...m redis since 2.6.

See Redis Release notes from 2.6: https://raw.github.com/antirez/redis/2.6/00-RELEASENOTES

Ultimately, this option should be removed eventually from this module - but for now to make this module backwards compatible - we should at least change this option to 'UNSET'.
