### PR TITLE
system_sysctl parameter for redis class; handles setting vm.overcommit_memory via 'sysctl' puppet module.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,3 +8,6 @@ description 'Module to install and configure a Redis server'
 project_page 'https://github.com/fsalum/puppet-redis'
 
 ## Add dependencies, if any:
+
+# https://forge.puppetlabs.com/thias/sysctl
+dependency 'thias/sysctl', '0.3.0'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Redis Module for Puppet
 =======================
 [![Build Status](https://secure.travis-ci.org/fsalum/puppet-redis.png)](http://travis-ci.org/fsalum/puppet-redis)
 
-This module install and manages the Redis server. All redis.conf options are
+This module installs and manages a Redis server. All redis.conf options are
 accepted in the parameterized class.
 
 Operating System
@@ -27,7 +27,15 @@ To change the port and listening network interface:
 Parameters
 ----------
 
-Check the [init.pp](https://github.com/fsalum/puppet-redis/blob/master/manifests/init.pp) file for a list of parameters accepted.
+Check the [init.pp](https://github.com/fsalum/puppet-redis/blob/master/manifests/init.pp) file for a complete list of parameters accepted.
+
+To enable and set important Linux kernel sysctl parameters as described in the [Redis Admin Guide](http://redis.io/topics/admin) - use the following configuration option:
+
+    class { 'redis':
+      system_sysctl => true
+    }
+
+By default, this sysctl parameter will not be enabled. Furthermore, you will need the sysctl module defined in the [Modulefile](https://github.com/fsalum/puppet-redis/blob/master/Modulefile) file.
 
 Copyright and License
 ---------------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,11 +5,9 @@
 # === Parameters
 #
 # All the redis.conf parameters can be passed to the class.
-# Check the README.md file
+# See below for a complete list of parameters accepted.
 #
-# === Variables
-#
-# Here you should define a list of variables that this module would require.
+# Check the README.md file for any further information about parameters for this class.
 #
 # === Examples
 #
@@ -30,6 +28,7 @@ class redis (
   $package_ensure                   = 'present',
   $service_ensure                   = 'running',
   $service_enable                   = true,
+  $system_sysctl                    = false,
   $conf_daemonize                   = 'yes',
   $conf_pidfile                     = 'UNSET',
   $conf_port                        = '6379',
@@ -150,6 +149,12 @@ class redis (
     mode    => 0755,
     before  => Service['redis'],
     require => Exec[$conf_dir],
+  }
+
+  if ( $system_sysctl == true ) {
+    # add necessary kernel parameters
+    # see the redis admin guide here: http://redis.io/topics/admin
+    sysctl { 'vm.overcommit_memory': value => '1' }
   }
 
 }


### PR DESCRIPTION
This commit adds a 'system_sysctl' parameter to Redis class.
This parameter is disabled (false) by default, but when enabled
sets the vm.overcommit_memory=1 sysctl setting on the Linux server.
In order to set this sysctl setting the sysctl module must be available.
The sysctl module required dependency was added to the Modulefile file.

The README.md file was updated to state how to use the 'system_sysctl'
parameter.

Some grammar changes.

ref: https://github.com/fsalum/puppet-redis/issues/18
