### PR TITLE
Unset cleanup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ class redis (
   $conf_daemonize                   = 'yes',
   $conf_pidfile                     = undef,
   $conf_port                        = '6379',
-  $conf_bind                        = '127.0.0.1',
+  $conf_bind                        = '0.0.0.0',
   $conf_timeout                     = '0',
   $conf_loglevel                    = 'notice',
   $conf_logfile                     = undef,

--- a/templates/redis.debian.conf.erb
+++ b/templates/redis.debian.conf.erb
@@ -14,9 +14,7 @@ port <%= @conf_port %>
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for connections.
 #
-<% @conf_bind %>
 bind <%= @conf_bind %>
-<% end %>
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout <%= @conf_timeout %>

--- a/templates/redis.rhel.conf.erb
+++ b/templates/redis.rhel.conf.erb
@@ -27,9 +27,7 @@ port <%= @conf_port %>
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
-<% if @conf_bind %>
 bind <%= @conf_bind %>
-<% end %>
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen


### PR DESCRIPTION
Cleanup use of the 'UNSET' string is favor of better Puppet design. 

Also change default behavior surrounding the bind directive. It will now listen on 0.0.0.0 by default. Generally speaking, this is a better best practice for module design. It imposes less policy on the people who will be using the module and leaves it as an exercise for them at implementation time.
