### PR TITLE
toggle ability to notify service to restart when config file changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,7 +112,9 @@ class redis (
     enable     => $service_enable,
     hasrestart => true,
     hasstatus  => true,
-    require    => Package['redis'],
+    require    => [ Package['redis'],
+                    Exec[$conf_dir],
+                    File[$conf_redis] ],
   }
 
   file { $conf_redis:


### PR DESCRIPTION
This change lets us push the configuration change and then do a controlled restart of services across our environment.  This is important because we have master/slave relationships and want to ensure that both are not restarted at once.
