### PR TITLE
Allowing redis package name as a param.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -11,3 +11,5 @@ project_page 'https://github.com/fsalum/puppet-redis'
 
 # https://forge.puppetlabs.com/thias/sysctl
 dependency 'thias/sysctl', '>= 0.3.0'
+# https://forge.puppetlabs.com/puppetlabs/stdlib/
+dependency 'puppetlabs/stdlib', '>= 3.2.1'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,7 @@ class redis (
   $conf_zset_max_ziplist_entries          = '128', # 2.4+
   $conf_zset_max_ziplist_value            = '64', # 2.4+
   $package_ensure                         = 'present',
+  $package_name                           = undef,
   $service_enable                         = true,
   $service_ensure                         = 'running',
   $service_restart                        = true,
@@ -108,7 +109,12 @@ class redis (
 
   $conf_redis     = $redis::params::conf
   $conf_logrotate = $redis::params::conf_logrotate
-  $package        = $redis::params::package
+  if is_string($package_name) {
+    $package     = $package_name
+  }
+  else {
+    $package      = $redis::params::package
+  }
   $service        = $redis::params::service
 
   if $conf_pidfile {


### PR DESCRIPTION
With this change, $package_name is added as a param in the base class for redis.
If the value is specified, it is used for $package throughout the module.
If the value is not specified, the current method of referencing params is used instead.
