### PR TITLE
the redis_version fact isn't always accurate on the first Puppet run.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,7 @@ class redis (
   $conf_zset_max_ziplist_value            = '64', # 2.4+
   $package_ensure                         = 'present',
   $package_name                           = undef,
+  $redis_version_override                 = undef,
   $service_enable                         = true,
   $service_ensure                         = 'running',
   $service_restart                        = true,
@@ -110,6 +111,18 @@ class redis (
   $conf_redis     = $redis::params::conf
   $conf_logrotate = $redis::params::conf_logrotate
   $service        = $redis::params::service
+
+  if $redis_version_override {
+    $redis_version_real = $redis_version_override
+  } else {
+    $redis_version_real = $package_ensure ? {
+      /2\.2\..*/ => '2.2.x',
+      /2\.4\..*/ => '2.4.x',
+      /2\.6\..*/ => '2.6.x',
+      /2\.8\..*/ => '2.8.x',
+      default => $::redis_version
+    }
+  }
 
   if $package_name {
     $package     = $package_name

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -1,4 +1,4 @@
-<%- if @redis_version == "2.2.x" -%>
+<%- if @redis_version_real == "2.2.x" -%>
 # MANAGED BY PUPPET #
 #
 # Redis 2.2 configuration file example
@@ -545,7 +545,7 @@ include <%= include %><%= "\n" -%>
 <%- end -%>
 <%- end -%>
 <%- end -%>
-<%- if @redis_version == "2.4.x" -%>
+<%- if @redis_version_real == "2.4.x" -%>
 # MANAGED BY PUPPET #
 #
 # Redis 2.4 configuration file example
@@ -1174,7 +1174,7 @@ include <%= include %><%= "\n" -%>
 <%- end -%>
 <%- end -%>
 <%- end -%>
-<%- if @redis_version == "2.6.x" -%>
+<%- if @redis_version_real == "2.6.x" -%>
 # MANAGED BY PUPPET #
 #
 # Redis 2.6 configuration file example
@@ -1903,7 +1903,7 @@ include <%= include %><%= "\n" -%>
 <%- end -%>
 <%- end -%>
 <%- end -%>
-<%- if @redis_version == "2.8.x" -%>
+<%- if @redis_version_real == "2.8.x" -%>
 # MANAGED BY PUPPET #
 #
 # Redis 2.8 configuration file example


### PR DESCRIPTION
It's calculated at the start of the run which can be problematic when a
package repo is introduced during the run containing a newer Redis
version or no Redis package was available at the start of the run.  In
the first case the fact will assume the lower version but during the run
after realizing a package repo containing a newer version a file
resource just set 'ensure => present' will install the later version and
result in a mismateched config file.  In the second sccenario
redis_version will be nil and result in a blank config file.

This change will:
- changes the template to use $redis_version_real
- if $redis_version_override is set then $redis_version_real will be set
  to that in order to handle the nil case in the fact.
- if $package_version is set to a package version then
  $redis_version_real will be set from that or use $redis_version

cc. @streed
