### PR TITLE
Remove from facter warning when redis is not installed

### DIFF
--- a/lib/facter/redis_version.rb
+++ b/lib/facter/redis_version.rb
@@ -12,7 +12,7 @@ Facter.add("redis_version", :timeout => 120) do
 
         redis_version = Facter::Util::Resolution.exec('/usr/bin/redis-server --version')
         if redis_version.nil?
-            redis_version = Facter::Util::Resolution.exec(dpkg+" show redis-server 2> /dev/null | /bin/grep -i 'version:' | /usr/bin/awk '{print $2}'").strip
+            redis_version = Facter::Util::Resolution.exec(dpkg+" show redis-server 2> /dev/null | /bin/grep -i 'version:' | /usr/bin/awk '{printf(\"%s\",$2)}'")
         end
 
         case redis_version
@@ -47,7 +47,7 @@ Facter.add("redis_version", :timeout => 120) do
 
         redis_version = Facter::Util::Resolution.exec('/usr/sbin/redis-server --version')
         if redis_version.nil?
-            redis_version = Facter::Util::Resolution.exec(yum+" info redis 2> /dev/null | /bin/grep '^Version' | /bin/awk -F ':' '{print $2}'").strip
+            redis_version = Facter::Util::Resolution.exec(yum+" info redis 2> /dev/null | /bin/grep '^Version' | /bin/awk -F ':' '{printf(\"%s\",$2)}'")
         end
 
         case redis_version


### PR DESCRIPTION
We used to see these messages when running puppet on a host w/o redis installed:
Could not retrieve redis_version: undefined method `strip' for nil:NilClass
Could not retrieve redis_version: undefined method`strip' for nil:NilClass
