### PR TITLE
Fixes and new init script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.1.6
+    env: PUPPET_GEM_VERSION="~> 4.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,12 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :test do
-  gem 'rake',                    :require => false
-  gem 'rspec-puppet',            :require => false
-  gem 'puppetlabs_spec_helper',  :require => false
-  gem 'serverspec',              :require => false
-  gem 'puppet-lint',             :require => false
-  gem 'beaker',                  :require => false
-  gem 'beaker-rspec',            :require => false
-  gem 'pry',                     :require => false
-  gem 'simplecov',               :require => false
+  gem 'rake',                   :require => false
+  gem 'rspec-puppet',           :require => false
+  gem 'puppetlabs_spec_helper', :require => false
+  gem 'puppet-lint',            :require => false
+  gem 'puppet_facts',           :require => false
+  gem 'metadata-json-lint',     :require => false
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+
 PuppetLint.configuration.fail_on_warnings
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_80chars')
@@ -9,16 +9,3 @@ PuppetLint.configuration.send('disable_class_parameter_defaults')
 PuppetLint.configuration.send('disable_documentation')
 PuppetLint.configuration.send('disable_single_quote_string_with_variables')
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
-
-desc "Validate manifests, templates, and ruby files in lib."
-task :validate do
-  Dir['manifests/**/*.pp'].each do |manifest|
-    sh "puppet parser validate --noop #{manifest}"
-  end
-  Dir['lib/**/*.rb'].each do |lib_file|
-    sh "ruby -c #{lib_file}"
-  end
-  Dir['templates/**/*.erb'].each do |template|
-    sh "erb -P -x -T '-' #{template} | ruby -c"
-  end
-end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ class redis (
   $conf_repl_ping_slave_period            = '10', # 2.4+
   $conf_repl_timeout                      = '60', # 2.4+
   $conf_requirepass                       = undef,
-  $conf_save                              = {"900" =>"1", "300" => "10", "60" => "10000"},
+  $conf_save                              = {'900' =>'1', '300' => '10', '60' => '10000'},
   $conf_set_max_intset_entries            = '512',
   $conf_slave_priority                    = undef, # 2.6+
   $conf_slave_read_only                   = 'yes', # 2.6+

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -45,7 +45,7 @@ class redis::sentinel (
   $service_enable           = true,
   $service_ensure           = 'running',
   $service_restart          = true,
-  $manage_upstart_scripts   = true,
+  $manage_init_scripts      = true,
   $package_name             = undef,
 ) {
 
@@ -55,7 +55,7 @@ class redis::sentinel (
   $conf_sentinel_orig = "${conf_sentinel}.puppet"
   $conf_logrotate     = $redis::sentinel_params::conf_logrotate
   $service            = $redis::sentinel_params::service
-  $upstart_script     = $redis::sentinel_params::upstart_script
+  $init_script        = $redis::sentinel_params::init_script
 
   if $package_name {
     $package     = $package_name
@@ -79,15 +79,15 @@ class redis::sentinel (
     name   => $package,
   }
 
-  if $manage_upstart_scripts == true {
+  if $manage_init_scripts == true {
     service { 'sentinel':
       ensure     => $service_ensure,
       name       => $service,
       hasrestart => true,
       hasstatus  => true,
       require    => [ File[$conf_sentinel_orig],
-                      File[$upstart_script] ],
-      provider   => 'upstart'
+                      File[$init_script] ],
+      provider   => 'init'
     }
   } else {
     service { 'sentinel':
@@ -141,8 +141,8 @@ class redis::sentinel (
     File[$conf_sentinel_orig] ~> Service['sentinel']
   }
 
-  if $manage_upstart_scripts == true {
-    file { $upstart_script:
+  if $manage_init_scripts == true {
+    file { $init_script:
       ensure  => present,
       content => template('redis/sentinel-init.conf.erb'),
       mode    => '0755',

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -41,7 +41,7 @@
 class redis::sentinel (
   $conf_port                = '26379',
   $conf_daemonize           = 'yes',
-  $sentinel_confs           = [],
+  $sentinel_confs           = {},
   $service_enable           = true,
   $service_ensure           = 'running',
   $service_restart          = true,
@@ -107,24 +107,23 @@ class redis::sentinel (
   # only if it changed.
   file { $conf_sentinel_orig:
     content => template('redis/sentinel.conf.erb'),
-    owner   => redis,
-    group   => redis,
+    owner   => root,
+    group   => root,
     mode    => '0644',
     require => Package['redis'],
     notify  => Exec["cp ${conf_sentinel_orig} ${conf_sentinel}"],
   }
 
   file { $conf_sentinel:
-    owner   => redis,
+    owner   => root,
     group   => redis,
+    mode    => '0664',
     require => Package['redis'],
   }
 
   exec { "cp ${conf_sentinel_orig} ${conf_sentinel}":
     path        => '/bin:/usr/bin:/sbin:/usr/sbin',
     refreshonly => true,
-    user        => redis,
-    group       => redis,
     notify      => Service['sentinel'],
     require     => File[$conf_sentinel],
   }
@@ -146,6 +145,7 @@ class redis::sentinel (
     file { $upstart_script:
       ensure  => present,
       content => template('redis/sentinel-init.conf.erb'),
+      mode    => '0755',
     }
   }
 

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -39,14 +39,14 @@
 # Copyright 2013 Felipe Salum, unless otherwise noted.
 #
 class redis::sentinel (
-  $conf_port                = '26379',
-  $conf_daemonize           = 'yes',
-  $sentinel_confs           = {},
-  $service_enable           = true,
-  $service_ensure           = 'running',
-  $service_restart          = true,
-  $manage_init_scripts      = true,
-  $package_name             = undef,
+  $conf_port           = '26379',
+  $conf_daemonize      = 'yes',
+  $sentinel_confs      = {},
+  $service_enable      = true,
+  $service_ensure      = 'running',
+  $service_restart     = true,
+  $manage_scripts      = true,
+  $package_name        = undef,
 ) {
 
   include redis::sentinel_params
@@ -55,7 +55,8 @@ class redis::sentinel (
   $conf_sentinel_orig = "${conf_sentinel}.puppet"
   $conf_logrotate     = $redis::sentinel_params::conf_logrotate
   $service            = $redis::sentinel_params::service
-  $init_script        = $redis::sentinel_params::init_script
+  $script             = $redis::sentinel_params::script
+  $template           = $redis::sentinel_params::template
 
   if $package_name {
     $package     = $package_name
@@ -79,15 +80,14 @@ class redis::sentinel (
     name   => $package,
   }
 
-  if $manage_init_scripts == true {
+  if $manage_scripts == true {
     service { 'sentinel':
       ensure     => $service_ensure,
       name       => $service,
       hasrestart => true,
       hasstatus  => true,
       require    => [ File[$conf_sentinel_orig],
-                      File[$init_script] ],
-      provider   => 'init'
+                      File[$script] ],
     }
   } else {
     service { 'sentinel':
@@ -141,10 +141,10 @@ class redis::sentinel (
     File[$conf_sentinel_orig] ~> Service['sentinel']
   }
 
-  if $manage_init_scripts == true {
-    file { $init_script:
+  if $manage_scripts == true {
+    file { $script:
       ensure  => present,
-      content => template('redis/sentinel-init.conf.erb'),
+      content => template($template),
       mode    => '0755',
     }
   }

--- a/manifests/sentinel_params.pp
+++ b/manifests/sentinel_params.pp
@@ -13,17 +13,17 @@
 class redis::sentinel_params {
 
   case $::osfamily {
-    # TODO: add redhat support
-    #'redhat': {
-    #  $package        = 'redis'
-    #  $service        = 'redis-sentinel'
-    #  $conf           = '/etc/sentinel.conf'
-    #  $conf_dir       = undef
-    #  $conf_logrotate = '/etc/logrotate.d/sentinel'
-    #  $pidfile        = '/var/run/redis/sentinel.pid'
-    #  $logfile        = '/var/log/redis/sentinel.log'
-    #  $upstart_script = '/etc/init/redis-sentinel.conf'
-    #}
+    'redhat': {
+      $package        = 'redis'
+      $service        = 'redis-sentinel'
+      $conf           = '/etc/sentinel.conf'
+      $conf_dir       = undef
+      $conf_logrotate = '/etc/logrotate.d/sentinel'
+      $pidfile        = '/var/run/redis/sentinel.pid'
+      $logfile        = '/var/log/redis/sentinel.log'
+      $script = '/etc/init.d/redis-sentinel'
+      $template       = 'redis/sentinel-systemd.conf.erb'
+    }
     'debian': {
       $package        = 'redis-server'
       $service        = 'redis-sentinel'
@@ -32,7 +32,9 @@ class redis::sentinel_params {
       $conf_logrotate = '/etc/logrotate.d/redis-sentinel'
       $pidfile        = '/var/run/redis/redis-sentinel.pid'
       $logfile        = '/var/log/redis/redis-sentinel.log'
-      $init_script    = '/etc/init.d/redis-sentinel'
+      $script         = '/etc/init.d/redis-sentinel'
+      $template       = 'redis/sentinel-init.conf.erb'
+
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily}, module ${module_name} only support osfamily RedHat and Debian")

--- a/manifests/sentinel_params.pp
+++ b/manifests/sentinel_params.pp
@@ -32,7 +32,7 @@ class redis::sentinel_params {
       $conf_logrotate = '/etc/logrotate.d/redis-sentinel'
       $pidfile        = '/var/run/redis/redis-sentinel.pid'
       $logfile        = '/var/log/redis/redis-sentinel.log'
-      $upstart_script = '/etc/init.d/redis-sentinel'
+      $init_script    = '/etc/init.d/redis-sentinel'
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily}, module ${module_name} only support osfamily RedHat and Debian")

--- a/manifests/sentinel_params.pp
+++ b/manifests/sentinel_params.pp
@@ -32,7 +32,7 @@ class redis::sentinel_params {
       $conf_logrotate = '/etc/logrotate.d/redis-sentinel'
       $pidfile        = '/var/run/redis/redis-sentinel.pid'
       $logfile        = '/var/log/redis/redis-sentinel.log'
-      $upstart_script = '/etc/init/redis-sentinel.conf'
+      $upstart_script = '/etc/init.d/redis-sentinel'
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily}, module ${module_name} only support osfamily RedHat and Debian")

--- a/manifests/sentinel_params.pp
+++ b/manifests/sentinel_params.pp
@@ -13,7 +13,7 @@
 class redis::sentinel_params {
 
   case $::osfamily {
-    'redhat': {
+    'RedHat': {
       $package        = 'redis'
       $service        = 'redis-sentinel'
       $conf           = '/etc/sentinel.conf'
@@ -21,7 +21,7 @@ class redis::sentinel_params {
       $conf_logrotate = '/etc/logrotate.d/sentinel'
       $pidfile        = '/var/run/redis/sentinel.pid'
       $logfile        = '/var/log/redis/sentinel.log'
-      $script = '/etc/init.d/redis-sentinel'
+      $script         = '/etc/init.d/redis-sentinel'
       $template       = 'redis/sentinel-systemd.conf.erb'
     }
     'debian': {

--- a/metadata.json
+++ b/metadata.json
@@ -3,26 +3,49 @@
   "version": "1.0.3",
   "author": "Felipe Salum",
   "summary": "Puppet module for Redis Server",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "source": "git://github.com/fsalum/puppet-redis.git",
   "project_page": "https://github.com/fsalum/puppet-redis",
   "issues_url": "https://github.com/fsalum/puppet-redis/issues",
   "tags": ["redis", "memcached", "cache", "nosql"],
   "operatingsystem_support": [
-        { "operatingsystem":"Centos",
-              "operatingsystemrelease":[ "5.0", "6.0" ] },
-        { "operatingsystem": "Ubuntu",
-              "operatingsystemrelease": [ "12.04", "13.10", "14.04" ] },
-        { "operatingsystem": "Debian",
-              "operatingsystemrelease": [ "6", "7" ] }
-    ],
+      {
+          "operatingsystem": "Centos",
+          "operatingsystemrelease": [
+              "5",
+              "6"
+          ]
+      },
+      {
+          "operatingsystem": "Ubuntu",
+          "operatingsystemrelease": [
+              "12.04",
+              "13.10",
+              "14.04"
+          ]
+      },
+      {
+          "operatingsystem":"Debian",
+          "operatingsystemrelease": [
+              "6",
+              "7"
+          ]
+      }
+  ],
   "requirements": [
-    { "name": "pe",
-      "version_requirement": "3.x" },
-    { "name": "puppet",
-      "version_requirement": "3.x" }
+    {
+        "name": "pe",
+        "version_requirement": "3.x"
+    },
+    {
+        "name": "puppet",
+        "version_requirement": "3.x"
+    }
   ],
   "dependencies": [
-    {"name":"thias/sysctl","version_requirement":">= 0.3.0"}
+    {
+        "name": "thias/sysctl",
+        "version_requirement": ">= 0.3.0"
+    }
   ]
 }

--- a/templates/sentinel-init.conf.erb
+++ b/templates/sentinel-init.conf.erb
@@ -1,14 +1,90 @@
-# redis-sentinel - Redis Datastore Server
-#
-# Redis is a key value in memory persistent datastore
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:             redis-sentinel
+# Required-Start:       $syslog $remote_fs
+# Required-Stop:        $syslog $remote_fs
+# Should-Start:         $local_fs
+# Should-Stop:          $local_fs
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    redis-sentinel - Redis availability monitor
+# Description:          redis-sentinel - Redis availability monitor
+### END INIT INFO
 
-start on (local-filesystems and runlevel [2345])
-stop on runlevel [016]
-respawn
-expect fork
-limit nofile 20000 65000
-pre-start script
-mkdir -p /var/run/redis-sentinel
-chown redis:redis /var/run/redis-sentinel
-end script
-exec start-stop-daemon --start --chuid redis:redis --pidfile <%= @conf_pidfile_real %> --umask 007 --exec /usr/bin/redis-sentinel -- <%= @conf_sentinel %>
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON_NAME=redis-server
+DAEMON=/usr/bin/redis-server
+DAEMON_ARGS="<%= @conf_sentinel %> --sentinel"
+NAME=redis-sentinel
+DESC=redis-sentinel
+
+RUNDIR=/var/run/redis-sentinel
+PIDFILE=<%= @conf_pidfile_real %>
+:
+test -x $DAEMON || exit 0
+
+if [ -r /etc/default/$NAME ]
+then
+        . /etc/default/$NAME
+fi
+
+. /lib/lsb/init-functions
+
+set -e
+
+case "$1" in
+  start)
+        echo -n "Starting $DESC: "
+        mkdir -p $RUNDIR
+        touch $PIDFILE
+        chown redis:redis $RUNDIR $PIDFILE
+        chmod 755 $RUNDIR
+
+        if [ -n "$ULIMIT" ]
+        then
+                ulimit -n $ULIMIT
+        fi
+
+        if start-stop-daemon --start --quiet --umask 007 --pidfile $PIDFILE --chuid redis:redis --exec $DAEMON -- $DAEMON_ARGS
+        then
+                echo "$NAME."
+        else
+                echo "failed"
+        fi
+        ;;
+  stop)
+        echo -n "Stopping $DESC: "
+        if start-stop-daemon --stop --retry forever/TERM/1 --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON
+        then
+                echo "$NAME."
+        else
+                echo "failed"
+        fi
+        rm -f $PIDFILE
+        sleep 1
+        ;;
+
+  restart|force-reload)
+        ${0} stop
+        ${0} start
+        ;;
+
+  status)
+        echo -n "$DESC is "
+        if start-stop-daemon --stop --quiet --signal 0 --name ${DAEMON_NAME} --pidfile ${PIDFILE}
+        then
+                echo "running"
+        else
+                echo "not running"
+                exit 1
+       fi
+        ;;
+
+  *)
+        echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload|status}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/templates/sentinel-systemd.conf.erb
+++ b/templates/sentinel-systemd.conf.erb
@@ -1,0 +1,89 @@
+#!/bin/sh
+#
+# redis        init file for starting up the redis sentinel daemon
+#
+# chkconfig:   - 20 80
+# description: Starts and stops the redis sentinel daemon.
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+name="redis-server"
+exec="/usr/sbin/$name"
+pidfile="<%= @conf_pidfile_real %>"
+SENTINEL_CONFIG="<%= @conf_sentinel %>"
+SENTINEL_ARGS="--sentinel"
+
+[ -e /etc/sysconfig/redis ] && . /etc/sysconfig/redis
+
+lockfile=/var/lock/subsys/redis-sentinel
+
+start() {
+    [ -f $SENTINEL_CONFIG ] || exit 6
+    [ -x $exec ] || exit 5
+    echo -n $"Starting $name: "
+    daemon --user ${REDIS_USER-redis} "$exec $SENTINEL_CONFIG $SENTINEL_ARGS"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $name: "
+    killproc -p $pidfile $name
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    false
+}
+
+rh_status() {
+    status -p $pidfile $name
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart}"
+        exit 2
+esac
+exit $?

--- a/tests/sentinel.pp
+++ b/tests/sentinel.pp
@@ -1,14 +1,14 @@
 node default {
 
   case $::osfamily {
-    #'RedHat': {
-    #  package { 'epel-release':
-    #    ensure   => present,
-    #    source   => 'http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm',
-    #    provider => rpm,
-    #    before   => Class['redis'],
-    #  }
-    #}
+    'RedHat': {
+      package { 'epel-release':
+        ensure   => present,
+        source   => 'http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm',
+        provider => rpm,
+        before   => Class['redis::sentinel'],
+      }
+    }
     'Debian': {
       # redis is on repository
     }


### PR DESCRIPTION
I found a few bugs when working with this new Sentinel feature.

First, `$sentinel_confs` expects a dictionary not an array.

Second, the permissions did now allow the `cp` operation to execute. `root` is the owner and `redis` cannot copy if the file does not exist.

I also modeled a new init script off of `/etc/init.d/redis-server`. It now has the ability to:
- `/etc/init.d/redis-sentinel start`
- `/etc/init.d/redis-sentinel stop`
- `/etc/init.d/redis-sentinel restart` or `force-reload`
- `/etc/init.d/redis-sentinel status`
