### PR TITLE
Redis port fact

### DIFF
--- a/lib/facter/redis_port.rb
+++ b/lib/facter/redis_port.rb
@@ -1,0 +1,31 @@
+require 'facter'
+
+Facter.add("redis_port", :timeout => 120) do
+    confine :osfamily => "Debian"
+
+    setcode do
+        redis_port = nil
+        if File.exists?("/etc/redis/redis.conf")
+            redis_port_grep = Facter::Util::Resolution.exec("grep '^port' /etc/redis/redis.conf | awk '{print $2}'")
+            if redis_port_grep =~ /^\d+$/
+                redis_port = redis_port_grep
+            end
+        end
+        redis_port
+    end
+end
+
+Facter.add("redis_port", :timeout => 120) do
+    confine :osfamily => "RedHat"
+
+    setcode do
+        redis_port = nil
+        if File.exists?("/etc/redis.conf")
+            redis_port_grep = Facter::Util::Resolution.exec("grep '^port' /etc/redis.conf | awk '{print $2}'")
+            if redis_port_grep =~ /^\d+$/
+                redis_port = redis_port_grep
+            end
+        end
+        redis_port
+    end
+end


### PR DESCRIPTION
This adds a simple redis_port fact that checks the port configuration in redis.conf as specified in the params module for each platform.