### PR TITLE
Template change refreshes redis service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,6 +165,7 @@ class redis (
     group   => root,
     mode    => '0644',
     require => Package['redis'],
+    notify  => Service['redis'],
   }
 
   file { $conf_logrotate:


### PR DESCRIPTION
I kept finding that my Debian-based systems weren't starting with the proper config. It turns out that, because Debian auto-starts the service, if you don't notify the service that the config is changed when dropping the template, you don't get your config. Thanks Debian. 

Anyway, this shouldn't adversely affect anything. 

Thanks! 

--Matt
