### PR TITLE
Enables specifying the service name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,6 +100,7 @@ class redis (
   $package_ensure                         = 'present',
   $package_name                           = undef,
   $redis_version_override                 = undef,
+  $service_name                           = undef,
   $service_enable                         = true,
   $service_ensure                         = 'running',
   $service_restart                        = true,
@@ -110,7 +111,13 @@ class redis (
 
   $conf_redis     = $redis::params::conf
   $conf_logrotate = $redis::params::conf_logrotate
-  $service        = $redis::params::service
+
+  if $service_name {
+    $service = $service_name
+  }else{
+    $service = $redis::params::service
+  }
+
 
   if $redis_version_override {
     $redis_version_real = $redis_version_override

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -90,6 +90,7 @@ node default {
     package_ensure                         => 'present',
     service_enable                         => true,
     service_ensure                         => 'running',
+    service_name                           => 'redis-server',
     service_restart                        => true,
     system_sysctl                          => true,
   }


### PR DESCRIPTION
This PR allows the service_name to be specified. The use case for this is when you manually download and install a version of Redis not available in the package repositories and create the upstart files yourself. It is also useful when you want to start and run several Redis instances on the same box.
