### PR TITLE
Corrected timeout settings for Puppet 4/Enterprise 2015.2.x compatbility

### DIFF
--- a/lib/facter/redis_version.rb
+++ b/lib/facter/redis_version.rb
@@ -1,6 +1,6 @@
 require 'facter'
 
-Facter.add("redis_version", :timeout => 120) do
+Facter.add("redis_version") do
     confine :osfamily => "Debian"
 
     setcode do
@@ -35,7 +35,7 @@ Facter.add("redis_version", :timeout => 120) do
     end
 end
 
-Facter.add("redis_version", :timeout => 120) do
+Facter.add("redis_version") do
     confine :osfamily => "RedHat"
 
     setcode do


### PR DESCRIPTION
Just removing the timeout to eliminate the ugly warning messages on runtime.
