### PR TITLE
Remove timeout option from custom fact

### DIFF
--- a/lib/facter/redis_version.rb
+++ b/lib/facter/redis_version.rb
@@ -1,6 +1,6 @@
 require 'facter'
 
-Facter.add("redis_version", :timeout => 120) do
+Facter.add("redis_version") do
     confine :osfamily => "Debian"
 
     setcode do
@@ -35,7 +35,7 @@ Facter.add("redis_version", :timeout => 120) do
     end
 end
 
-Facter.add("redis_version", :timeout => 120) do
+Facter.add("redis_version") do
     confine :osfamily => "RedHat"
 
     setcode do


### PR DESCRIPTION
It seems to be not supported anymore: 

``
Warning: Facter: timeout option is not supported for custom facts and will be ignored.
``